### PR TITLE
[bugfix] Ignore the `require` and `path`

### DIFF
--- a/lib/bundle-locker.rb
+++ b/lib/bundle-locker.rb
@@ -35,8 +35,8 @@ module Bundle
               else
                 replacement << "'#{dictionary[:locked_version]}'\n"
               end
-              # not replace prefix `require` and `path`
-              unless dictionary[:original].match(/(require|path)/)
+              # not replace prefix `require`, `path` and `branch`
+              unless dictionary[:original].match(/(require|path|branch)/)
                 contents.gsub!(dictionary[:original], replacement)
               end
             end

--- a/lib/bundle-locker.rb
+++ b/lib/bundle-locker.rb
@@ -35,7 +35,10 @@ module Bundle
               else
                 replacement << "'#{dictionary[:locked_version]}'\n"
               end
-              contents.gsub!(dictionary[:original], replacement)
+              # not replace prefix `require` and `path`
+              unless dictionary[:original].match(/(require|path)/)
+                contents.gsub!(dictionary[:original], replacement)
+              end
             end
           end
           file.puts contents

--- a/lib/bundle-locker/version.rb
+++ b/lib/bundle-locker/version.rb
@@ -1,5 +1,5 @@
 module Bundle
   module Locker
-    VERSION = "0.0.6"
+    VERSION = "0.0.7"
   end
 end

--- a/lib/bundle-locker/version.rb
+++ b/lib/bundle-locker/version.rb
@@ -1,5 +1,5 @@
 module Bundle
   module Locker
-    VERSION = "0.0.5"
+    VERSION = "0.0.6"
   end
 end


### PR DESCRIPTION
I found a bug, 
if I put the prefix `require` and `path`, the prefix has erased after execute.

```
gem 'daemon-spawn', '0.4.2', :require => 'daemon_spawn'
gem 'rails_admin_mongoid-grid_fs', path: 'vendor/custom_gems/rails_admin_mongoid-grid_fs'
```

So I changed it below.

thanks